### PR TITLE
BZ-1251856 Fix version to 2.1.28.SP1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.jboss.spec.javax.faces</groupId>
   <artifactId>jboss-jsf-api_2.1_spec</artifactId>
-  <version>2.1.28.SP1.Final</version>
+  <version>2.1.28.SP1</version>
   <packaging>jar</packaging>
 
   <name>JavaServer(TM) Faces 2.1 API</name>


### PR DESCRIPTION
The version 2.1.28.SP1.Final is not a valid release string.
This PR fixes version to 2.1.28.SP1. Please do the tag (jboss-jsf-api_2.1_spec-2.1.28.SP1) when it's merged. Thanks!