### PR TITLE
[WFLY-9838] JAVASERVERFACES_SPEC_PUBLIC-671 The old model value is re…

### DIFF
--- a/src/main/java/javax/faces/component/UIInput.java
+++ b/src/main/java/javax/faces/component/UIInput.java
@@ -259,9 +259,11 @@ public class UIInput extends UIOutput implements EditableValueHolder {
      * its corresponding {@link Renderer}.</p>
      */
     public Object getSubmittedValue() {
-
-        return (this.submittedValue);
-
+        if (submittedValue == null && !isValid() && considerEmptyStringNull(FacesContext.getCurrentInstance())) { // JAVASERVERFACES_SPEC_PUBLIC-671
+            return "";
+        } else {
+            return submittedValue;
+        }
     }
 
 


### PR DESCRIPTION
…displayed on @NotNull validation error with INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL=true
JIRA: https://issues.jboss.org/browse/WFLY-9838