### PR TITLE
[Mojarra 4553] Mojarra 4553 - Resoures#encodeAll doesn't work anymore…

### DIFF
--- a/src/main/java/javax/faces/component/UIViewRoot.java
+++ b/src/main/java/javax/faces/component/UIViewRoot.java
@@ -968,7 +968,8 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor {
     public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {
         FacesContext context = event.getFacesContext();
 
-        if (event instanceof PostRestoreStateEvent && context.getPartialViewContext().isPartialRequest()) {
+        if (event instanceof PostRestoreStateEvent && context.getPartialViewContext().isPartialRequest()
+                && !context.getPartialViewContext().isRenderAll()) {
             ResourceHandler resourceHandler = context.getApplication().getResourceHandler();
 
             for (UIComponent resource : getComponentResources(context)) {


### PR DESCRIPTION
… since 2.3.x

Upstream Issue: https://github.com/eclipse-ee4j/mojarra/issues/4553
[Upstream PR: https://github.com/eclipse-ee4j/mojarra/pull/4630]

2.3.9 PR: https://github.com/jboss/jboss-jsf-api_spec/pull/15