### PR TITLE
JBEAP-17499 2nd part fix for TCK failure, If the component is NOT val…

### DIFF
--- a/src/main/java/javax/faces/component/UIInput.java
+++ b/src/main/java/javax/faces/component/UIInput.java
@@ -1047,7 +1047,7 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             }
         }
 
-        if (compareValues(previous, newValue)) {
+        if (isValid() && compareValues(previous, newValue)) {
             queueEvent(new ValueChangeEvent(context, this, previous, newValue));
         }
 


### PR DESCRIPTION
2nd part fix for TCK failure, If the component is NOT valid, the associated ValueChangeListener must NOT be invoked

Issue: https://issues.redhat.com/browse/JBEAP-17499
Upstream issue: https://issues.redhat.com/browse/JBEAP-17931

Upstream 3.0.0.SP PR: https://github.com/jboss/jboss-jakarta-faces-api/pull/8
