### PR TITLE
[WFLY-13571] make the extra validation only on UIViewParameter.

### DIFF
--- a/src/main/java/javax/faces/component/UIInput.java
+++ b/src/main/java/javax/faces/component/UIInput.java
@@ -1010,8 +1010,9 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             if (isRequired() && isSetAlwaysValidateRequired(context)) {
                 // continue as below
             } else {
-                if(considerEmptyStringNull(context)) {
+                if (this instanceof UIViewParameter && considerEmptyStringNull(context)) {
                     // https://github.com/eclipse-ee4j/mojarra/issues/4550
+                    // https://github.com/eclipse-ee4j/mojarra/issues/4716
                     validateValue(context,  getConvertedValue(context, submittedValue));
                 }
                 return;


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/JBEAP-19594
upstream issue: https://issues.redhat.com/browse/JBEAP-19593
WFLY issue: https://issues.redhat.com/browse/WFLY-13571

Upstream PR: https://github.com/jboss/jboss-jakarta-faces-api/pull/10

Last pull request https://github.com/jboss/jboss-jsf-api_spec/pull/20 addressed the JAVASERVERFACES_SPEC_PUBLIC-1329 validation requirement inside UIInput.java rather than UIViewParameter.java. However, the extra validation should have only applied on UIViewParameter.
